### PR TITLE
Update freenas_5a_loopd.md

### DIFF
--- a/FreeNAS/bitcoin/freenas_5a_loopd.md
+++ b/FreeNAS/bitcoin/freenas_5a_loopd.md
@@ -23,7 +23,7 @@ Check [lightning lab's loop github repo](https://github.com/lightninglabs/loop/r
 ### loopd Startup and initialization
 Start `loopd`:
 ```
-# loopd --lnd.macaroondir=/var/db/lnd/data/chain/bitcoin/mainnet --lnd.tlspath=/var/db/lnd/tls.cert --server.proxy=localhost:9050
+# loopd --lnd.macaroonpath=/var/db/lnd/data/chain/bitcoin/mainnet/admin.macaroon --lnd.tlspath=/var/db/lnd/tls.cert --server.proxy=localhost:9050
 ```
 If it works, you should see the following message:
 ```
@@ -67,7 +67,7 @@ Paste the following service script into nano:
 name="loopd"
 rcvar="loopd_enable"
 
-loopd_command="/usr/local/bin/loopd --lnd.macaroondir=/var/db/lnd/data/chain/bitcoin/mainnet --lnd.tlspath=/var/db/lnd/tls.cert --server.proxy=localhost:9050"
+loopd_command="/usr/local/bin/loopd --lnd.macaroonpath=/var/db/lnd/data/chain/bitcoin/mainnet/admin.macaroon --lnd.tlspath=/var/db/lnd/tls.cert --server.proxy=localhost:9050"
 pidfile="/var/run/${name}.pid"
 command="/usr/sbin/daemon"
 command_args="-P ${pidfile} -r -f ${loopd_command}"


### PR DESCRIPTION
Loopd errors out when executing with --lnd.macaroondir, "use only --lnd.macaroonpath", linked to admin.macaroon.