### PR TITLE
Update freenas_5_lnd.md

### DIFF
--- a/FreeNAS/bitcoin/freenas_5_lnd.md
+++ b/FreeNAS/bitcoin/freenas_5_lnd.md
@@ -153,7 +153,7 @@ Read the release notes, if a lot changed, you may have to close channels or do s
 ```
 # service lnd stop
 # cd ~
-# wget https://github.com/lightningnetwork/lnd/releases/download/v0.13.0-beta/lnd-freebsd-amd64-v0.13.0-beta.tar.gz
+# wget https://github.com/lightningnetwork/lnd/releases/download/v0.13.3-beta/lnd-freebsd-amd64-v0.13.3-beta.tar.gz
 # tar -xvf lnd-freebsd-amd64*
 # install -m 0755 -o root -g wheel ~/lnd-freebsd-amd64*/* /usr/local/bin
 # rm -r /lnd-freebsd-amd64* lnd-freebsd-amd64*

--- a/FreeNAS/bitcoin/freenas_5_lnd.md
+++ b/FreeNAS/bitcoin/freenas_5_lnd.md
@@ -15,7 +15,7 @@ Check [LND's github repo](https://github.com/lightningnetwork/lnd/releases) for 
 ```
 # pkg install wget ca_root_nss
 # cd ~
-# wget https://github.com/lightningnetwork/lnd/releases/download/v0.13.0-beta/lnd-freebsd-amd64-v0.13.0-beta.tar.gz
+# wget https://github.com/lightningnetwork/lnd/releases/download/v0.13.3-beta/lnd-freebsd-amd64-v0.13.3-beta.tar.gz
 # tar -xvf lnd-freebsd-amd64*
 # install -m 0755 -o root -g wheel ~/lnd-freebsd-amd64*/* /usr/local/bin
 # rm -r /lnd-freebsd-amd64* lnd-freebsd-amd64*


### PR DESCRIPTION
This release contains a security fix for [CVE-2021-41593](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-41593) which would allow an attacker to cause loss of funds through a griefing vector related to high accepted dust values.